### PR TITLE
Add on-demand file downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The playlist ID is what appears in the address bar when visiting a YouTube playl
 
 *Note:* Private playlists aren't supported (might be possible after [this issue](https://github.com/reibitto/podpodge/issues/1) is addressed). Using unlisted playlists is the closest alternative for now.
 
-If successful, this should return you a JSON response of the Podcast. You can then use the `POST /podcasts/check` route to check for and download the episodes:
+If successful, this should return you a JSON response of the Podcast. You can then use the `POST /podcasts/check` route to check for new episodes:
 
 (*Note:* There is an [issue](https://github.com/reibitto/podpodge/issues/8) for setting up CRON-like schedules per Podcast for automatic checks)
 

--- a/core/src/main/scala/podpodge/DownloadWorker.scala
+++ b/core/src/main/scala/podpodge/DownloadWorker.scala
@@ -3,9 +3,9 @@ package podpodge
 import podpodge.db.Episode
 import podpodge.db.dao.EpisodeDao
 import podpodge.types._
-import podpodge.youtube.{ PlaylistItem, YouTubeDL }
-import sttp.client.httpclient.zio.SttpClient
+import podpodge.youtube.PlaylistItem
 import sttp.client._
+import sttp.client.httpclient.zio.SttpClient
 import sttp.model.Uri
 import zio.blocking.Blocking
 import zio.duration._
@@ -21,39 +21,38 @@ object DownloadWorker {
         val videoId = request.playlistItem.snippet.resourceId.videoId
 
         (for {
-          downloadedFile <- YouTubeDL.download(request.podcastId, videoId)
-          episode        <- EpisodeDao.create(
-                              Episode(
-                                EpisodeId.empty,
-                                request.podcastId,
-                                videoId,
-                                videoId,
-                                request.playlistItem.snippet.title,
-                                request.playlistItem.snippet.publishedAt, // TODO: Add config option to select `request.playlistItem.contentDetails.videoPublishedAt` here
-                                None,
-                                Some(downloadedFile.getName),
-                                0.seconds                                 // TODO: Calculate duration
-                              )
-                            )
-          _              <- ZIO.foreach_(request.playlistItem.snippet.thumbnails.highestRes) { thumbnail =>
-                              for {
-                                uri <- ZIO.fromEither(Uri.parse(thumbnail.url)).catchAll(ZIO.dieMessage(_))
-                                req  = basicRequest
-                                         .get(uri)
-                                         .response(
-                                           asPath(
-                                             Config.thumbnailsPath
-                                               .resolve(request.podcastId.unwrap.toString)
-                                               .resolve(s"${episode.id}.jpg")
-                                           )
-                                         )
+          episode <- EpisodeDao.create(
+                       Episode(
+                         EpisodeId.empty,
+                         request.podcastId,
+                         videoId,
+                         videoId,
+                         request.playlistItem.snippet.title,
+                         request.playlistItem.snippet.publishedAt, // TODO: Add config option to select `request.playlistItem.contentDetails.videoPublishedAt` here
+                         None,
+                         None,
+                         0.seconds                                 // TODO: Calculate duration
+                       )
+                     )
+          _       <- ZIO.foreach_(request.playlistItem.snippet.thumbnails.highestRes) { thumbnail =>
+                       for {
+                         uri <- ZIO.fromEither(Uri.parse(thumbnail.url)).catchAll(ZIO.dieMessage(_))
+                         req  = basicRequest
+                                  .get(uri)
+                                  .response(
+                                    asPath(
+                                      Config.thumbnailsPath
+                                        .resolve(request.podcastId.unwrap.toString)
+                                        .resolve(s"${episode.id}.jpg")
+                                    )
+                                  )
 
-                                downloadedThumbnail <- SttpClient.send(req)
-                                _                   <- ZIO.whenCase(downloadedThumbnail.body) { case Right(_) =>
-                                                         EpisodeDao.updateImage(episode.id, Some(s"${episode.id}.jpg"))
-                                                       }
-                              } yield ()
-                            }
+                         downloadedThumbnail <- SttpClient.send(req)
+                         _                   <- ZIO.whenCase(downloadedThumbnail.body) { case Right(_) =>
+                                                  EpisodeDao.updateImage(episode.id, Some(s"${episode.id}.jpg"))
+                                                }
+                       } yield ()
+                     }
         } yield ()).absorb.tapError { t =>
           log.throwable(s"Error downloading video '$videoId'", t)
         }.ignore

--- a/core/src/main/scala/podpodge/db/dao/EpisodeDao.scala
+++ b/core/src/main/scala/podpodge/db/dao/EpisodeDao.scala
@@ -60,6 +60,13 @@ object EpisodeDao extends SqlDao {
       }
     }
 
+  def updateMediaFile(id: EpisodeId, s: Option[String]): Task[Long] =
+    Task {
+      ctx.run {
+        query[Episode.Model].filter(_.id == lift(id)).update(_.mediaFile -> lift(s))
+      }
+    }
+
   def delete(id: EpisodeId): Task[Long] =
     Task {
       ctx.run {

--- a/core/src/main/scala/podpodge/http/HttpError.scala
+++ b/core/src/main/scala/podpodge/http/HttpError.scala
@@ -1,5 +1,5 @@
 package podpodge.http
 
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.marshalling.ToResponseMarshaller
 
-final case class HttpError(result: ToResponseMarshallable) extends Exception()
+final case class HttpError[A: ToResponseMarshaller](result: A) extends Exception()

--- a/core/src/main/scala/podpodge/server/PodpodgeServer.scala
+++ b/core/src/main/scala/podpodge/server/PodpodgeServer.scala
@@ -1,39 +1,45 @@
 package podpodge.server
 
+import java.io.File
+
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.Http
 import podpodge.db.Migration
+import podpodge.types.EpisodeId
 import podpodge.{ Config, DownloadRequest, DownloadWorker }
 import sttp.client.httpclient.zio.SttpClient
 import zio.blocking.Blocking
 import zio.logging.{ log, Logging }
-import zio.{ Task, ZManaged, ZQueue }
+import zio._
 
 object PodpodgeServer {
   def make: ZManaged[Logging with Blocking with SttpClient, Throwable, Http.ServerBinding] = {
     implicit val system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "podpodge-system")
 
     for {
-      _             <- ZManaged
-                         .dieMessage("You need a YouTube API to run Podpodge. Refer to the README for further details.")
-                         .when(Config.apiKey.isEmpty)
-      _             <- Migration.migrate.toManaged_
-      _             <- Config.ensureDirectoriesExist.toManaged_
-      downloadQueue <- ZManaged.fromEffect(ZQueue.unbounded[DownloadRequest])
-      _             <- DownloadWorker.make(downloadQueue).forkDaemon.toManaged_
-      server        <- ZManaged.make(
-                         Task.fromFuture { _ =>
-                           Http().newServerAt(Config.serverInterface, Config.serverPort).bind(Routes.make(downloadQueue))
-                         }
-                       )(server =>
-                         (for {
-                           _ <- log.info("Shutting down server")
-                           _ <- Task.fromFuture(_ => server.unbind())
-                           _ <- Task(system.terminate())
-                           _ <- Task.fromFuture(_ => system.whenTerminated)
-                         } yield ()).orDie
-                       )
+      _                   <- ZManaged
+                               .dieMessage("You need a YouTube API to run Podpodge. Refer to the README for further details.")
+                               .when(Config.apiKey.isEmpty)
+      _                   <- Migration.migrate.toManaged_
+      _                   <- Config.ensureDirectoriesExist.toManaged_
+      downloadQueue       <- ZManaged.fromEffect(ZQueue.unbounded[DownloadRequest])
+      _                   <- DownloadWorker.make(downloadQueue).forkDaemon.toManaged_
+      episodesDownloading <- ZRefM.makeManaged(Map.empty[EpisodeId, Promise[Throwable, File]])
+      server              <- ZManaged.make(
+                               Task.fromFuture { _ =>
+                                 Http()
+                                   .newServerAt(Config.serverInterface, Config.serverPort)
+                                   .bind(Routes.make(downloadQueue, episodesDownloading))
+                               }
+                             )(server =>
+                               (for {
+                                 _ <- log.info("Shutting down server")
+                                 _ <- Task.fromFuture(_ => server.unbind())
+                                 _ <- Task(system.terminate())
+                                 _ <- Task.fromFuture(_ => system.whenTerminated)
+                               } yield ()).orDie
+                             )
     } yield server
   }
 }

--- a/core/src/main/scala/podpodge/youtube/YouTubeDL.scala
+++ b/core/src/main/scala/podpodge/youtube/YouTubeDL.scala
@@ -12,8 +12,7 @@ import zio.{ RIO, Task }
 
 object YouTubeDL {
   def download(podcastId: PodcastId, videoId: String): RIO[Blocking with Logging, File] = {
-    val audioFormat = "mp3"
-
+    val audioFormat           = "mp3"
     val podcastAudioDirectory = Config.audioPath.resolve(podcastId.unwrap.toString)
     val outputFile            = podcastAudioDirectory.resolve(s"${videoId}.${audioFormat}").toFile
 


### PR DESCRIPTION
Rather than pre-downloading all the recent episodes, files are now downloaded on-demand (when your Podcast client actually requests for the file).