### PR TITLE
Fix local URI for Directory podcasts

### DIFF
--- a/core/src/main/scala/podpodge/controllers/PodcastController.scala
+++ b/core/src/main/scala/podpodge/controllers/PodcastController.scala
@@ -137,9 +137,9 @@ object PodcastController {
       .filterNot(item => excludeExternalPaths.contains(item))
       .filter { s =>
         s.extension match {
-          case Some(ext) if Set("mp3", "ogg").contains(ext.toLowerCase) =>
+          case Some(ext) if Set("mp3", "ogg", "m4a").contains(ext.toLowerCase) =>
             true
-          case _                                                        => false
+          case _                                                               => false
         }
       }
       .foreach { item =>

--- a/core/src/main/scala/podpodge/db/Episode.scala
+++ b/core/src/main/scala/podpodge/db/Episode.scala
@@ -27,9 +27,7 @@ final case class Episode[ID](
 
   def linkUrl(sourceType: SourceType): Uri = sourceType match {
     case SourceType.YouTube   => uri"https://www.youtube.com/playlist?list=$externalSource"
-    case SourceType.Directory =>
-      val file = new File(externalSource)
-      Uri.unsafeParse(s"file://${file.getCanonicalPath}")
+    case SourceType.Directory => Uri(new File(externalSource).toURI)
   }
 }
 

--- a/core/src/main/scala/podpodge/db/Podcast.scala
+++ b/core/src/main/scala/podpodge/db/Podcast.scala
@@ -34,9 +34,7 @@ final case class Podcast[ID](
 
   def linkUrl: Uri = sourceType match {
     case SourceType.YouTube   => uri"https://www.youtube.com/playlist?list=$externalSource"
-    case SourceType.Directory =>
-      val file = new File(externalSource)
-      Uri.unsafeParse(s"file://${file.getCanonicalPath}")
+    case SourceType.Directory => Uri(new File(externalSource).toURI)
   }
 }
 


### PR DESCRIPTION
Use `File#toURI` instead of building the file URI unsafely (which was buggy at least on Windows)